### PR TITLE
notebooks: clarifying license

### DIFF
--- a/notebooks/sky130-raw-data-viz.ipynb
+++ b/notebooks/sky130-raw-data-viz.ipynb
@@ -40,7 +40,7 @@
       "source": [
         "```\n",
         "Copyright 2022 Google LLC.\n",
-        "SPDX-License-Identifier: GPL-3.0-or-later\n",
+        "SPDX-License-Identifier: Apache-2.0\n",
         "```"
       ],
       "metadata": {


### PR DESCRIPTION
Related #7 

The code of the notebook itself is released under `Apache-2.0` (while the distributed of the combined work would be under `GPL-3.0-or-later`).
